### PR TITLE
Use vh instead of rem for text editor padding

### DIFF
--- a/src/components/text-field/index.jsx
+++ b/src/components/text-field/index.jsx
@@ -16,7 +16,7 @@ function TextField() {
     <div className="flex w-full h-full">
       <TextareaAutosize
         placeholder="Once upon a time..."
-        className="min-h-full border-none outline-none text-neutral-900 placeholder:text-neutral-400 dark:text-neutral-300 dark:placeholder:text-neutral-600 font-mono text-base max-xs:text-xs max-sm:text-xs leading-loose flex-1 resize-none overflow-hidden bg-transparent ml-10 md:ml-12 lg:ml-0 xl:ml-0 2xl:ml-0 pb-72 pt-4 pl-0 pr-4 md:px-28 md:pt-20 lg:px-60 lg:pt-20 xl:px-80 xl:pt-20 2xl:px-80 2xl:pt-20"
+        className="min-h-full border-none outline-none text-neutral-900 placeholder:text-neutral-400 dark:text-neutral-300 dark:placeholder:text-neutral-600 font-mono text-base max-xs:text-xs max-sm:text-xs leading-loose flex-1 resize-none overflow-hidden bg-transparent ml-10 md:ml-12 lg:ml-0 xl:ml-0 2xl:ml-0 pb-[45vh] pt-4 pl-0 pr-4 md:px-28 md:pt-20 lg:px-60 lg:pt-20 xl:px-80 xl:pt-20 2xl:px-80 2xl:pt-20"
         spellCheck={false}
         onInput={updateText}
         onHeightChange={scrollToBottom}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ export default {
       mono: ['"Fira Code"', 'monospace']
     },
     extend: {
+      padding: {
+        '45vh': '45vh'
+      },
       translate: {
         neg50: '-50%'
       }


### PR DESCRIPTION
Used viewport height units rather than rems to define the padding at the bottom of the text editor. It gives it a more consistent layout across platforms.